### PR TITLE
Unobtrusive backups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/BedrockService/BackupFile.cs
+++ b/BedrockService/BackupFile.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BedrockService
+{
+    internal class BackupFile
+    {
+        public long Length { get; }
+
+        public string Path { get; }
+
+        private BackupFile(string path, long length)
+        {
+            Path = path;
+            Length = length;
+        }
+
+        public static bool IsBackupSpecification(string input)
+        {
+            return input?.Contains(".ldb:") ?? false;
+        }
+
+        public static List<BackupFile> ParseBackupSpecification(string input)
+        {
+            return input
+                .Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(ParseFileSpec)
+                .ToList();
+        }
+
+        private static BackupFile ParseFileSpec(string fileSpec)
+        {
+            var chunks = fileSpec.Split(':');
+
+            // bedrock server returns paths with forward slashes,
+            // but since we're on windows we need to convert them to backslashes
+            var path = chunks[0].Replace('/', '\\');
+            return new BackupFile(path, long.Parse(chunks[1]));
+        }
+    }
+}

--- a/BedrockService/BedrockService.csproj
+++ b/BedrockService/BedrockService.csproj
@@ -93,6 +93,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppSettings.cs" />
+    <Compile Include="BackupFile.cs" />
     <Compile Include="BedrockServerWrapper.cs" />
     <Compile Include="BedrockServiceWrapper.cs" />
     <Compile Include="IWCFConsoleServer.cs" />

--- a/BedrockService/BedrockService.csproj
+++ b/BedrockService/BedrockService.csproj
@@ -65,8 +65,8 @@
     <Reference Include="INIFileParser, Version=2.5.2.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
       <HintPath>packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="NCrontab.Signed, Version=3.3.2.0, Culture=neutral, PublicKeyToken=5247b4370afff365, processorArchitecture=MSIL">
       <HintPath>packages\NCrontab.Signed.3.3.2\lib\net35\NCrontab.Signed.dll</HintPath>

--- a/BedrockService/BedrockServiceWrapper.cs
+++ b/BedrockService/BedrockServiceWrapper.cs
@@ -135,22 +135,7 @@ namespace BedrockService
         {
             foreach (var brs in bedrockServers.OrderByDescending(t => t.ServerConfig.Primary).ToList())
             {
-                brs.Stopping = true;
-                if (!stopping) brs.StopControl();
-                Thread.Sleep(1000);
-            }
-
-            foreach (var brs in bedrockServers.OrderByDescending(t => t.ServerConfig.Primary).ToList())
-            {
                 if (!stopping) brs.Backup();
-
-            }
-            foreach (var brs in bedrockServers.OrderByDescending(t => t.ServerConfig.Primary).ToList())
-            {
-                brs.Stopping = false;
-                if (!stopping) brs.StartControl(_hostControl);
-                Thread.Sleep(2000);
-
             }
         }
 


### PR DESCRIPTION
I spotted that with bedrock server now supports taking backups via command line (at least as of version 1.21.30.03). 

What's cool about it that it doesn't require server stop, so basically you can take backups as frequently as you wish and it's not going to disrupt gameplay.

Concept is that you send it a command to prepare to backup, then poll it if it's ready. When it's ready, it gives you exact list of files to backup and their lengths. They you copy and trim them, if anything is longer, and that's exactly your backup.  You can check minecraft's bedrock_server_how_to.html for more details.

So, I've replaced current backup routine (stop, copy everything, start) with logic based on those commands. It works, though I can't say I thoroughly tested it: I played on it for a bit, it was taking backups, and I tried few of those backups afterwards, they seemed ok.