### PR TITLE
Backup file names fix

### DIFF
--- a/BedrockService/BedrockServerWrapper.cs
+++ b/BedrockService/BedrockServerWrapper.cs
@@ -284,7 +284,7 @@ namespace BedrockService
                 }
 
                 var sourceDirectory = exe.Directory.GetDirectories().Single(t => t.Name == worldsFolder);
-                var targetDirectory = backupTo.CreateSubdirectory($"{worldsFolder}{DateTime.Now.ToString("yyyyMMddhhmmss")}");
+                var targetDirectory = backupTo.CreateSubdirectory($"{worldsFolder}{DateTime.Now:yyyyMMddHHmmss}");
                 CopyBackupFiles(sourceDirectory, targetDirectory, backupFiles);
             }
             catch (Exception e)


### PR DESCRIPTION
There was a bug with the backup file names. It would store them in a 12-hour format, which isn't good, since then two backups 12 hours apart could have the same name. This had caused some corruption among the backups. I fixed it by making the backup names unique.